### PR TITLE
Migrate benches to criterion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,6 +122,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cc"
 version = "1.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +141,33 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
 
 [[package]]
 name = "clap"
@@ -165,6 +213,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,6 +281,12 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "either"
@@ -285,10 +375,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
+name = "half"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "image"
@@ -314,10 +420,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "libc"
@@ -368,6 +510,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,11 +541,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "oorandom"
+version = "11.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+
+[[package]]
 name = "oxipng"
 version = "9.1.5"
 dependencies = [
  "bitvec",
  "clap",
+ "criterion",
  "crossbeam-channel",
  "env_logger",
  "filetime",
@@ -419,6 +574,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
+
+[[package]]
 name = "png"
 version = "0.17.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -429,6 +612,24 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
+dependencies = [
+ "proc-macro2",
 ]
 
 [[package]]
@@ -467,6 +668,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
 name = "rgb"
 version = "0.8.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -495,6 +725,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustversion"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.141"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -513,6 +796,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "syn"
+version = "2.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -529,10 +823,113 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
 name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,27 @@ required-features = ["binary"]
 [[bench]]
 name = "zopfli"
 required-features = ["zopfli"]
+harness = false
+
+[[bench]]
+name = "deflate"
+harness = false
+
+[[bench]]
+name = "filters"
+harness = false
+
+[[bench]]
+name = "interlacing"
+harness = false
+
+[[bench]]
+name = "reductions"
+harness = false
+
+[[bench]]
+name = "strategies"
+harness = false
 
 [dependencies]
 zopfli = { version = "0.8.2", optional = true, default-features = false, features = ["std", "zlib"] }
@@ -78,6 +99,9 @@ optional = true
 default-features = false
 features = ["png"]
 version = "0.25.6"
+
+[dev-dependencies]
+criterion = "0.5"
 
 [features]
 binary = ["dep:clap", "dep:glob", "dep:env_logger"]

--- a/benches/deflate.rs
+++ b/benches/deflate.rs
@@ -1,63 +1,51 @@
-#![feature(test)]
-
-extern crate oxipng;
-extern crate test;
-
 use std::path::PathBuf;
 
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use oxipng::{internal_tests::*, *};
-use test::Bencher;
 
-#[bench]
-fn deflate_16_bits(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
+fn deflate_benchmarks(c: &mut Criterion) {
+    let input = black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("deflate_16_bits", |b| {
+        b.iter(|| deflate(png.raw.data.as_ref(), 12, None))
+    });
 
-    b.iter(|| deflate(png.raw.data.as_ref(), 12, None));
-}
-
-#[bench]
-fn deflate_8_bits(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
+    let input = black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("deflate_8_bits", |b| {
+        b.iter(|| deflate(png.raw.data.as_ref(), 12, None))
+    });
 
-    b.iter(|| deflate(png.raw.data.as_ref(), 12, None));
-}
-
-#[bench]
-fn deflate_4_bits(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/palette_4_should_be_palette_4.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("deflate_4_bits", |b| {
+        b.iter(|| deflate(png.raw.data.as_ref(), 12, None))
+    });
 
-    b.iter(|| deflate(png.raw.data.as_ref(), 12, None));
-}
-
-#[bench]
-fn deflate_2_bits(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/palette_2_should_be_palette_2.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("deflate_2_bits", |b| {
+        b.iter(|| deflate(png.raw.data.as_ref(), 12, None))
+    });
 
-    b.iter(|| deflate(png.raw.data.as_ref(), 12, None));
-}
-
-#[bench]
-fn deflate_1_bits(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/palette_1_should_be_palette_1.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("deflate_1_bits", |b| {
+        b.iter(|| deflate(png.raw.data.as_ref(), 12, None))
+    });
 
-    b.iter(|| deflate(png.raw.data.as_ref(), 12, None));
-}
-
-#[bench]
-fn inflate_generic(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
+    let input = black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
     let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| inflate(png.idat_data.as_ref(), png.raw.ihdr.raw_data_size()));
+    c.bench_function("inflate_generic", |b| {
+        b.iter(|| inflate(png.idat_data.as_ref(), png.raw.ihdr.raw_data_size()))
+    });
 }
+
+criterion_group!(benches, deflate_benchmarks);
+criterion_main!(benches);

--- a/benches/filters.rs
+++ b/benches/filters.rs
@@ -1,285 +1,40 @@
-#![feature(test)]
-
-extern crate oxipng;
-extern crate test;
-
 use std::path::PathBuf;
 
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use oxipng::{internal_tests::*, *};
-use test::Bencher;
 
-#[bench]
-fn filters_16_bits_filter_0(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
-    let png = PngData::new(&input, &Options::default()).unwrap();
+fn filters_benchmarks(c: &mut Criterion) {
+    let mut group = c.benchmark_group("filters");
 
-    b.iter(|| png.raw.filter_image(RowFilter::None, false));
+    let cases = [
+        ("16_bits", "tests/files/rgb_16_should_be_rgb_16.png"),
+        ("8_bits", "tests/files/rgb_8_should_be_rgb_8.png"),
+        ("4_bits", "tests/files/palette_4_should_be_palette_4.png"),
+        ("2_bits", "tests/files/palette_2_should_be_palette_2.png"),
+        ("1_bits", "tests/files/palette_1_should_be_palette_1.png"),
+    ];
+    let filters = [
+        ("filter_0", RowFilter::None),
+        ("filter_1", RowFilter::Sub),
+        ("filter_2", RowFilter::Up),
+        ("filter_3", RowFilter::Average),
+        ("filter_4", RowFilter::Paeth),
+        ("filter_5", RowFilter::MinSum),
+    ];
+
+    for (bit_label, path) in cases {
+        for (filter_label, filter) in filters {
+            let name = format!("filters_{}_{}", bit_label, filter_label);
+            let input = black_box(PathBuf::from(path));
+            let png = PngData::new(&input, &Options::default()).unwrap();
+            group.bench_function(name, move |b| {
+                b.iter(|| png.raw.filter_image(filter, false))
+            });
+        }
+    }
+
+    group.finish();
 }
 
-#[bench]
-fn filters_8_bits_filter_0(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::None, false));
-}
-
-#[bench]
-fn filters_4_bits_filter_0(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
-        "tests/files/palette_4_should_be_palette_4.png",
-    ));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::None, false));
-}
-
-#[bench]
-fn filters_2_bits_filter_0(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
-        "tests/files/palette_2_should_be_palette_2.png",
-    ));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::None, false));
-}
-
-#[bench]
-fn filters_1_bits_filter_0(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
-        "tests/files/palette_1_should_be_palette_1.png",
-    ));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::None, false));
-}
-
-#[bench]
-fn filters_16_bits_filter_1(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::Sub, false));
-}
-
-#[bench]
-fn filters_8_bits_filter_1(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::Sub, false));
-}
-
-#[bench]
-fn filters_4_bits_filter_1(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
-        "tests/files/palette_4_should_be_palette_4.png",
-    ));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::Sub, false));
-}
-
-#[bench]
-fn filters_2_bits_filter_1(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
-        "tests/files/palette_2_should_be_palette_2.png",
-    ));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::Sub, false));
-}
-
-#[bench]
-fn filters_1_bits_filter_1(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
-        "tests/files/palette_1_should_be_palette_1.png",
-    ));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::Sub, false));
-}
-
-#[bench]
-fn filters_16_bits_filter_2(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::Up, false));
-}
-
-#[bench]
-fn filters_8_bits_filter_2(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::Up, false));
-}
-
-#[bench]
-fn filters_4_bits_filter_2(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
-        "tests/files/palette_4_should_be_palette_4.png",
-    ));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::Up, false));
-}
-
-#[bench]
-fn filters_2_bits_filter_2(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
-        "tests/files/palette_2_should_be_palette_2.png",
-    ));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::Up, false));
-}
-
-#[bench]
-fn filters_1_bits_filter_2(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
-        "tests/files/palette_1_should_be_palette_1.png",
-    ));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::Up, false));
-}
-
-#[bench]
-fn filters_16_bits_filter_3(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::Average, false));
-}
-
-#[bench]
-fn filters_8_bits_filter_3(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::Average, false));
-}
-
-#[bench]
-fn filters_4_bits_filter_3(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
-        "tests/files/palette_4_should_be_palette_4.png",
-    ));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::Average, false));
-}
-
-#[bench]
-fn filters_2_bits_filter_3(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
-        "tests/files/palette_2_should_be_palette_2.png",
-    ));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::Average, false));
-}
-
-#[bench]
-fn filters_1_bits_filter_3(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
-        "tests/files/palette_1_should_be_palette_1.png",
-    ));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::Average, false));
-}
-
-#[bench]
-fn filters_16_bits_filter_4(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::Paeth, false));
-}
-
-#[bench]
-fn filters_8_bits_filter_4(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::Paeth, false));
-}
-
-#[bench]
-fn filters_4_bits_filter_4(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
-        "tests/files/palette_4_should_be_palette_4.png",
-    ));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::Paeth, false));
-}
-
-#[bench]
-fn filters_2_bits_filter_4(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
-        "tests/files/palette_2_should_be_palette_2.png",
-    ));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::Paeth, false));
-}
-
-#[bench]
-fn filters_1_bits_filter_4(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
-        "tests/files/palette_1_should_be_palette_1.png",
-    ));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::Paeth, false));
-}
-
-#[bench]
-fn filters_16_bits_filter_5(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::MinSum, false));
-}
-
-#[bench]
-fn filters_8_bits_filter_5(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::MinSum, false));
-}
-
-#[bench]
-fn filters_4_bits_filter_5(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
-        "tests/files/palette_4_should_be_palette_4.png",
-    ));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::MinSum, false));
-}
-
-#[bench]
-fn filters_2_bits_filter_5(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
-        "tests/files/palette_2_should_be_palette_2.png",
-    ));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::MinSum, false));
-}
-
-#[bench]
-fn filters_1_bits_filter_5(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
-        "tests/files/palette_1_should_be_palette_1.png",
-    ));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::MinSum, false));
-}
+criterion_group!(benches, filters_benchmarks);
+criterion_main!(benches);

--- a/benches/reductions.rs
+++ b/benches/reductions.rs
@@ -1,281 +1,223 @@
-#![feature(test)]
-
-extern crate oxipng;
-extern crate test;
-
 use std::path::PathBuf;
 
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use oxipng::{internal_tests::*, *};
-use test::Bencher;
 
-#[bench]
-fn reductions_16_to_8_bits(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_8.png"));
+fn reductions_benchmarks(c: &mut Criterion) {
+    let input = black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_8.png"));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_16_to_8_bits", |b| {
+        b.iter(|| bit_depth::reduced_bit_depth_16_to_8(&png.raw, false))
+    });
 
-    b.iter(|| bit_depth::reduced_bit_depth_16_to_8(&png.raw, false));
-}
-
-#[bench]
-fn reductions_16_to_8_bits_scaled(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
+    let input = black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_16_to_8_bits_scaled", |b| {
+        b.iter(|| bit_depth::reduced_bit_depth_16_to_8(&png.raw, true))
+    });
 
-    b.iter(|| bit_depth::reduced_bit_depth_16_to_8(&png.raw, true));
-}
-
-#[bench]
-fn reductions_8_to_4_bits(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/palette_8_should_be_palette_4.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_8_to_4_bits", |b| {
+        b.iter(|| bit_depth::reduced_bit_depth_8_or_less(&png.raw))
+    });
 
-    b.iter(|| bit_depth::reduced_bit_depth_8_or_less(&png.raw));
-}
-
-#[bench]
-fn reductions_8_to_2_bits(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/palette_8_should_be_palette_2.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_8_to_2_bits", |b| {
+        b.iter(|| bit_depth::reduced_bit_depth_8_or_less(&png.raw))
+    });
 
-    b.iter(|| bit_depth::reduced_bit_depth_8_or_less(&png.raw));
-}
-
-#[bench]
-fn reductions_8_to_1_bits(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/palette_8_should_be_palette_1.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_8_to_1_bits", |b| {
+        b.iter(|| bit_depth::reduced_bit_depth_8_or_less(&png.raw))
+    });
 
-    b.iter(|| bit_depth::reduced_bit_depth_8_or_less(&png.raw));
-}
-
-#[bench]
-fn reductions_grayscale_8_to_4_bits(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/grayscale_8_should_be_grayscale_4.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_grayscale_8_to_4_bits", |b| {
+        b.iter(|| bit_depth::reduced_bit_depth_8_or_less(&png.raw))
+    });
 
-    b.iter(|| bit_depth::reduced_bit_depth_8_or_less(&png.raw));
-}
-
-#[bench]
-fn reductions_grayscale_8_to_2_bits(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/grayscale_8_should_be_grayscale_2.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_grayscale_8_to_2_bits", |b| {
+        b.iter(|| bit_depth::reduced_bit_depth_8_or_less(&png.raw))
+    });
 
-    b.iter(|| bit_depth::reduced_bit_depth_8_or_less(&png.raw));
-}
-
-#[bench]
-fn reductions_grayscale_8_to_1_bits(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/grayscale_8_should_be_grayscale_1.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_grayscale_8_to_1_bits", |b| {
+        b.iter(|| bit_depth::reduced_bit_depth_8_or_less(&png.raw))
+    });
 
-    b.iter(|| bit_depth::reduced_bit_depth_8_or_less(&png.raw));
-}
-
-#[bench]
-fn reductions_rgba_to_rgb_16(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgba_16_should_be_rgb_16.png"));
+    let input = black_box(PathBuf::from("tests/files/rgba_16_should_be_rgb_16.png"));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_rgba_to_rgb_16", |b| {
+        b.iter(|| alpha::reduced_alpha_channel(&png.raw, true))
+    });
 
-    b.iter(|| alpha::reduced_alpha_channel(&png.raw, true));
-}
-
-#[bench]
-fn reductions_rgba_to_rgb_8(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgba_8_should_be_rgb_8.png"));
+    let input = black_box(PathBuf::from("tests/files/rgba_8_should_be_rgb_8.png"));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_rgba_to_rgb_8", |b| {
+        b.iter(|| alpha::reduced_alpha_channel(&png.raw, true))
+    });
 
-    b.iter(|| alpha::reduced_alpha_channel(&png.raw, true));
-}
-
-#[bench]
-fn reductions_rgba_to_rgb_trns_8(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgba_8_should_be_rgb_trns_8.png"));
+    let input = black_box(PathBuf::from("tests/files/rgba_8_should_be_rgb_trns_8.png"));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_rgba_to_rgb_trns_8", |b| {
+        b.iter(|| alpha::reduced_alpha_channel(&png.raw, true))
+    });
 
-    b.iter(|| alpha::reduced_alpha_channel(&png.raw, true));
-}
-
-#[bench]
-fn reductions_rgba_to_grayscale_alpha_16(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/rgba_16_should_be_grayscale_alpha_16.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_rgba_to_grayscale_alpha_16", |b| {
+        b.iter(|| color::reduced_rgb_to_grayscale(&png.raw))
+    });
 
-    b.iter(|| color::reduced_rgb_to_grayscale(&png.raw));
-}
-
-#[bench]
-fn reductions_rgba_to_grayscale_alpha_8(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/rgba_8_should_be_grayscale_alpha_8.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_rgba_to_grayscale_alpha_8", |b| {
+        b.iter(|| color::reduced_rgb_to_grayscale(&png.raw))
+    });
 
-    b.iter(|| color::reduced_rgb_to_grayscale(&png.raw));
-}
-
-#[bench]
-fn reductions_rgb_to_grayscale_16(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/rgb_16_should_be_grayscale_16.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_rgb_to_grayscale_16", |b| {
+        b.iter(|| color::reduced_rgb_to_grayscale(&png.raw))
+    });
 
-    b.iter(|| color::reduced_rgb_to_grayscale(&png.raw));
-}
-
-#[bench]
-fn reductions_rgb_to_grayscale_8(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_grayscale_8.png"));
+    let input = black_box(PathBuf::from("tests/files/rgb_8_should_be_grayscale_8.png"));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_rgb_to_grayscale_8", |b| {
+        b.iter(|| color::reduced_rgb_to_grayscale(&png.raw))
+    });
 
-    b.iter(|| color::reduced_rgb_to_grayscale(&png.raw));
-}
-
-#[bench]
-fn reductions_rgba_to_palette_8(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgba_8_should_be_palette_8.png"));
+    let input = black_box(PathBuf::from("tests/files/rgba_8_should_be_palette_8.png"));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_rgba_to_palette_8", |b| {
+        b.iter(|| color::reduced_to_indexed(&png.raw, true))
+    });
 
-    b.iter(|| color::reduced_to_indexed(&png.raw, true));
-}
-
-#[bench]
-fn reductions_rgb_to_palette_8(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_palette_8.png"));
+    let input = black_box(PathBuf::from("tests/files/rgb_8_should_be_palette_8.png"));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_rgb_to_palette_8", |b| {
+        b.iter(|| color::reduced_to_indexed(&png.raw, true))
+    });
 
-    b.iter(|| color::reduced_to_indexed(&png.raw, true));
-}
-
-#[bench]
-fn reductions_grayscale_alpha_to_grayscale_16(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/grayscale_alpha_16_should_be_grayscale_16.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_grayscale_alpha_to_grayscale_16", |b| {
+        b.iter(|| alpha::reduced_alpha_channel(&png.raw, true))
+    });
 
-    b.iter(|| alpha::reduced_alpha_channel(&png.raw, true));
-}
-
-#[bench]
-fn reductions_grayscale_alpha_to_grayscale_8(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/grayscale_alpha_8_should_be_grayscale_8.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_grayscale_alpha_to_grayscale_8", |b| {
+        b.iter(|| alpha::reduced_alpha_channel(&png.raw, true))
+    });
 
-    b.iter(|| alpha::reduced_alpha_channel(&png.raw, true));
-}
-
-#[bench]
-fn reductions_grayscale_alpha_to_grayscale_trns_8(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/grayscale_alpha_8_should_be_grayscale_trns_8.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_grayscale_alpha_to_grayscale_trns_8", |b| {
+        b.iter(|| alpha::reduced_alpha_channel(&png.raw, true))
+    });
 
-    b.iter(|| alpha::reduced_alpha_channel(&png.raw, true));
-}
-
-#[bench]
-fn reductions_grayscale_8_to_palette_8(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/grayscale_8_should_be_palette_8.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_grayscale_8_to_palette_8", |b| {
+        b.iter(|| color::reduced_to_indexed(&png.raw, true))
+    });
 
-    b.iter(|| color::reduced_to_indexed(&png.raw, true));
-}
-
-#[bench]
-fn reductions_palette_8_to_grayscale_8(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/palette_8_should_be_grayscale_8.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_palette_8_to_grayscale_8", |b| {
+        b.iter(|| color::indexed_to_channels(&png.raw, true, false))
+    });
 
-    b.iter(|| color::indexed_to_channels(&png.raw, true, false));
-}
-
-#[bench]
-fn reductions_palette_duplicate_reduction(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/palette_should_be_reduced_with_dupes.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_palette_duplicate_reduction", |b| {
+        b.iter(|| palette::reduced_palette(&png.raw, false))
+    });
 
-    b.iter(|| palette::reduced_palette(&png.raw, false));
-}
-
-#[bench]
-fn reductions_palette_unused_reduction(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/palette_should_be_reduced_with_unused.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_palette_unused_reduction", |b| {
+        b.iter(|| palette::reduced_palette(&png.raw, false))
+    });
 
-    b.iter(|| palette::reduced_palette(&png.raw, false));
-}
-
-#[bench]
-fn reductions_palette_full_reduction(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/palette_should_be_reduced_with_both.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_palette_full_reduction", |b| {
+        b.iter(|| palette::reduced_palette(&png.raw, false))
+    });
 
-    b.iter(|| palette::reduced_palette(&png.raw, false));
-}
-
-#[bench]
-fn reductions_palette_sort(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/palette_8_should_be_palette_8.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_palette_sort", |b| {
+        b.iter(|| palette::sorted_palette(&png.raw))
+    });
 
-    b.iter(|| palette::sorted_palette(&png.raw));
-}
-
-#[bench]
-fn reductions_palette_sort_mzeng(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/palette_8_should_be_palette_8.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_palette_sort_mzeng", |b| {
+        b.iter(|| palette::sorted_palette_mzeng(&png.raw))
+    });
 
-    b.iter(|| palette::sorted_palette_mzeng(&png.raw));
-}
-
-#[bench]
-fn reductions_palette_sort_battiato(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/palette_8_should_be_palette_8.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("reductions_palette_sort_battiato", |b| {
+        b.iter(|| palette::sorted_palette_battiato(&png.raw))
+    });
 
-    b.iter(|| palette::sorted_palette_battiato(&png.raw));
-}
-
-#[bench]
-fn reductions_alpha(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgba_8_reduce_alpha.png"));
+    let input = black_box(PathBuf::from("tests/files/rgba_8_reduce_alpha.png"));
     let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| alpha::cleaned_alpha_channel(&png.raw));
+    c.bench_function("reductions_alpha", |b| {
+        b.iter(|| alpha::cleaned_alpha_channel(&png.raw))
+    });
 }
+
+criterion_group!(benches, reductions_benchmarks);
+criterion_main!(benches);

--- a/benches/strategies.rs
+++ b/benches/strategies.rs
@@ -1,49 +1,39 @@
-#![feature(test)]
-
-extern crate oxipng;
-extern crate test;
-
 use std::path::PathBuf;
 
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use oxipng::{internal_tests::*, *};
-use test::Bencher;
 
-#[bench]
-fn filters_minsum(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
+fn strategies_benchmarks(c: &mut Criterion) {
+    let input = black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
     let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("filters_minsum", |b| {
+        b.iter(|| png.raw.filter_image(RowFilter::MinSum, false))
+    });
 
-    b.iter(|| png.raw.filter_image(RowFilter::MinSum, false));
+    let input = black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
+    let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("filters_entropy", |b| {
+        b.iter(|| png.raw.filter_image(RowFilter::Entropy, false))
+    });
+
+    let input = black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
+    let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("filters_bigrams", |b| {
+        b.iter(|| png.raw.filter_image(RowFilter::Bigrams, false))
+    });
+
+    let input = black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
+    let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("filters_bigent", |b| {
+        b.iter(|| png.raw.filter_image(RowFilter::BigEnt, false))
+    });
+
+    let input = black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
+    let png = PngData::new(&input, &Options::default()).unwrap();
+    c.bench_function("filters_brute", |b| {
+        b.iter(|| png.raw.filter_image(RowFilter::Brute, false))
+    });
 }
 
-#[bench]
-fn filters_entropy(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::Entropy, false));
-}
-
-#[bench]
-fn filters_bigrams(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::Bigrams, false));
-}
-
-#[bench]
-fn filters_bigent(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::BigEnt, false));
-}
-
-#[bench]
-fn filters_brute(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
-    let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| png.raw.filter_image(RowFilter::Brute, false));
-}
+criterion_group!(benches, strategies_benchmarks);
+criterion_main!(benches);

--- a/benches/zopfli.rs
+++ b/benches/zopfli.rs
@@ -1,68 +1,58 @@
-#![feature(test)]
-
-extern crate oxipng;
-extern crate test;
-
 use std::{num::NonZeroU8, path::PathBuf};
 
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use oxipng::{internal_tests::*, *};
-use test::Bencher;
 
 // SAFETY: trivially safe. Stopgap solution until const unwrap is stabilized.
 const DEFAULT_ZOPFLI_ITERATIONS: NonZeroU8 = unsafe { NonZeroU8::new_unchecked(15) };
 
-#[bench]
-fn zopfli_16_bits_strategy_0(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
+fn zopfli_benchmarks(c: &mut Criterion) {
+    let input = black_box(PathBuf::from("tests/files/rgb_16_should_be_rgb_16.png"));
     let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| {
-        zopfli_deflate(png.raw.data.as_ref(), DEFAULT_ZOPFLI_ITERATIONS).ok();
+    c.bench_function("zopfli_16_bits_strategy_0", |b| {
+        b.iter(|| {
+            zopfli_deflate(png.raw.data.as_ref(), DEFAULT_ZOPFLI_ITERATIONS).ok();
+        })
     });
-}
 
-#[bench]
-fn zopfli_8_bits_strategy_0(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
+    let input = black_box(PathBuf::from("tests/files/rgb_8_should_be_rgb_8.png"));
     let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| {
-        zopfli_deflate(png.raw.data.as_ref(), DEFAULT_ZOPFLI_ITERATIONS).ok();
+    c.bench_function("zopfli_8_bits_strategy_0", |b| {
+        b.iter(|| {
+            zopfli_deflate(png.raw.data.as_ref(), DEFAULT_ZOPFLI_ITERATIONS).ok();
+        })
     });
-}
 
-#[bench]
-fn zopfli_4_bits_strategy_0(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/palette_4_should_be_palette_4.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| {
-        zopfli_deflate(png.raw.data.as_ref(), DEFAULT_ZOPFLI_ITERATIONS).ok();
+    c.bench_function("zopfli_4_bits_strategy_0", |b| {
+        b.iter(|| {
+            zopfli_deflate(png.raw.data.as_ref(), DEFAULT_ZOPFLI_ITERATIONS).ok();
+        })
     });
-}
 
-#[bench]
-fn zopfli_2_bits_strategy_0(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/palette_2_should_be_palette_2.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| {
-        zopfli_deflate(png.raw.data.as_ref(), DEFAULT_ZOPFLI_ITERATIONS).ok();
+    c.bench_function("zopfli_2_bits_strategy_0", |b| {
+        b.iter(|| {
+            zopfli_deflate(png.raw.data.as_ref(), DEFAULT_ZOPFLI_ITERATIONS).ok();
+        })
     });
-}
 
-#[bench]
-fn zopfli_1_bits_strategy_0(b: &mut Bencher) {
-    let input = test::black_box(PathBuf::from(
+    let input = black_box(PathBuf::from(
         "tests/files/palette_1_should_be_palette_1.png",
     ));
     let png = PngData::new(&input, &Options::default()).unwrap();
-
-    b.iter(|| {
-        zopfli_deflate(png.raw.data.as_ref(), DEFAULT_ZOPFLI_ITERATIONS).ok();
+    c.bench_function("zopfli_1_bits_strategy_0", |b| {
+        b.iter(|| {
+            zopfli_deflate(png.raw.data.as_ref(), DEFAULT_ZOPFLI_ITERATIONS).ok();
+        })
     });
 }
+
+criterion_group!(benches, zopfli_benchmarks);
+criterion_main!(benches);


### PR DESCRIPTION
## Summary
- replace nightly benches with criterion
- define bench targets in Cargo.toml
- add criterion as a dev dependency

## Testing
- `cargo test --all --release --no-run`
- `cargo bench --no-run`


------
https://chatgpt.com/codex/tasks/task_e_687e2a9150948325ae574433953b7615